### PR TITLE
Add Interviewer Notes feature

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d candidates listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED =
+            "Notes cannot exceed 450 characters. Current length: %1$d characters.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/NotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NotesCommand.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Notes;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds interviewer notes to an existing candidate in RecruitIntel.
+ */
+public class NotesCommand extends Command {
+
+    public static final String COMMAND_WORD = "note";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds interviewer notes to the candidate identified "
+            + "by the index number used in the displayed candidate list.\n"
+            + "Parameters: INDEX (must be a positive integer) NOTE_TEXT (maximum 450 characters)\n"
+            + "Example: " + COMMAND_WORD + " 1 Strong backend experience, but lacks iOS exposure.";
+
+    public static final String MESSAGE_ADD_NOTES_SUCCESS = "Note added to candidate #%1$d: \"%2$s\"";
+
+    private final Index targetIndex;
+    private final Notes notes;
+
+    /**
+     * @param targetIndex of the candidate in the filtered candidate list to add notes to
+     * @param notes the notes to add to the candidate
+     */
+    public NotesCommand(Index targetIndex, Notes notes) {
+        requireNonNull(targetIndex);
+        requireNonNull(notes);
+
+        this.targetIndex = targetIndex;
+        this.notes = notes;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToAddNotesTo = lastShownList.get(targetIndex.getZeroBased());
+        Person updatedPerson = new Person(
+                personToAddNotesTo.getName(),
+                personToAddNotesTo.getPhone(),
+                personToAddNotesTo.getEmail(),
+                personToAddNotesTo.getAddress(),
+                personToAddNotesTo.getJobPosition(),
+                personToAddNotesTo.getTeam(),
+                personToAddNotesTo.getTags(),
+                notes
+        );
+
+        model.setPerson(personToAddNotesTo, updatedPerson);
+
+        return new CommandResult(String.format(MESSAGE_ADD_NOTES_SUCCESS, targetIndex.getOneBased(), notes.value));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NotesCommand)) {
+            return false;
+        }
+
+        NotesCommand otherNotesCommand = (NotesCommand) other;
+        return targetIndex.equals(otherNotesCommand.targetIndex)
+                && notes.equals(otherNotesCommand.notes);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .add("notes", notes)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.NotesCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case NotesCommand.COMMAND_WORD:
+            return new NotesCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/NotesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NotesCommandParser.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED;
+
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.NotesCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Notes;
+
+/**
+ * Parses input arguments and creates a new NotesCommand object
+ */
+public class NotesCommandParser implements Parser<NotesCommand> {
+
+    private static final Logger logger = LogsCenter.getLogger(NotesCommandParser.class);
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the NotesCommand
+     * and returns a NotesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public NotesCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            logger.info("Empty arguments provided for notes command");
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+        }
+
+        String[] parts = trimmedArgs.split("\\s+", 2);
+        if (parts.length < 2) {
+            logger.info("Insufficient arguments provided for notes command");
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(parts[0]);
+            logger.fine("Index parsed successfully: " + index.getOneBased());
+        } catch (ParseException pe) {
+            logger.info("Failed to parse index: " + parts[0]);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE), pe);
+        }
+
+        String notesText = parts[1].trim();
+        if (notesText.length() > Notes.MAX_LENGTH) {
+            logger.info("Notes exceed character limit: " + notesText.length() + " characters");
+            throw new ParseException(
+                    String.format(MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED, notesText.length()));
+        }
+
+        Notes notes = new Notes(notesText);
+        logger.fine("Notes parsed successfully: " + notes.value);
+
+        return new NotesCommand(index, notes);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Notes.java
+++ b/src/main/java/seedu/address/model/person/Notes.java
@@ -1,0 +1,66 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents interviewer notes for a Candidate in RecruitIntel.
+ * Guarantees: immutable; is valid as declared in {@link #isValidNotes(String)}
+ */
+public class Notes {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Notes cannot exceed 450 characters in length.";
+
+    public static final int MAX_LENGTH = 450;
+
+    /*
+     * Notes can be any string up to MAX_LENGTH characters
+     */
+    public static final String VALIDATION_REGEX = "^.{0," + MAX_LENGTH + "}$";
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Notes}.
+     *
+     * @param notes A valid notes string.
+     */
+    public Notes(String notes) {
+        requireNonNull(notes);
+        checkArgument(isValidNotes(notes), MESSAGE_CONSTRAINTS);
+        value = notes;
+    }
+
+    /**
+     * Returns true if a given string is valid for notes.
+     * A valid notes string must not exceed MAX_LENGTH characters.
+     */
+    public static boolean isValidNotes(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Notes)) {
+            return false;
+        }
+
+        Notes otherNotes = (Notes) other;
+        return value.equals(otherNotes.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,13 +26,22 @@ public class Person {
     private final JobPosition jobPosition;
     private final Team team;
     private final Set<Tag> tags = new HashSet<>();
+    private final Notes notes;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, JobPosition jobPosition,
                   Team team, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, jobPosition, team, tags);
+        this(name, phone, email, address, jobPosition, team, tags, new Notes(""));
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Person(Name name, Phone phone, Email email, Address address, JobPosition jobPosition,
+                  Team team, Set<Tag> tags, Notes notes) {
+        requireAllNonNull(name, phone, email, address, jobPosition, team, tags, notes);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -40,6 +49,7 @@ public class Person {
         this.jobPosition = jobPosition;
         this.team = team;
         this.tags.addAll(tags);
+        this.notes = notes;
     }
 
     public Name getName() {
@@ -66,6 +76,10 @@ public class Person {
         return team;
     }
 
+    public Notes getNotes() {
+        return notes;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -86,7 +100,6 @@ public class Person {
         return otherPerson != null
                 && otherPerson.getEmail().equals(getEmail());
     }
-
 
     /**
      * Returns true if both candidates have the same identity and data fields.
@@ -110,13 +123,14 @@ public class Person {
                 && address.equals(otherPerson.address)
                 && jobPosition.equals(otherPerson.jobPosition)
                 && team.equals(otherPerson.team)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && notes.equals(otherPerson.notes);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, jobPosition, team, tags);
+        return Objects.hash(name, phone, email, address, jobPosition, team, tags, notes);
     }
 
     @Override
@@ -129,6 +143,7 @@ public class Person {
                 .add("jobPosition", jobPosition)
                 .add("team", team)
                 .add("tags", tags)
+                .add("notes", notes)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.JobPosition;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Team;
@@ -24,27 +25,49 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new Address("Blk 30 Geylang Street 29, #06-40"),
                     new JobPosition("Software Engineer"), new Team("iOS Development"),
-                    getTagSet("swift", "senior")),
+                    getTagSet("swift", "senior"),
+                    new Notes("Strong in iOS development with 8 years of experience. Demonstrated excellent "
+                            + "knowledge of Swift and SwiftUI. "
+                            + "Led multiple App Store releases with 4.8+ ratings. Potential tech lead material. "
+                            + "Particularly impressed with his system design solutions during the technical interview. "
+                            + "Shows great mentorship capabilities with junior developers.")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     new JobPosition("UI/UX Designer"), new Team("Design"),
-                    getTagSet("figma", "experienced")),
+                    getTagSet("figma", "experienced"),
+                    new Notes("Portfolio shows strong visual design skills and user-centric thinking. "
+                            + "Great presentation on improving the Apple Store app UX. Highly collaborative. "
+                            + "Previous experience at top design agencies is evident in her work quality.")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                     new JobPosition("Hardware Engineer"), new Team("Chip Design"),
-                    getTagSet("verilog", "fresh")),
+                    getTagSet("verilog", "fresh"),
+                    new Notes("Recent graduate with impressive academic projects in FPGA design. "
+                            + "Shows promise in chip architecture concepts. "
+                            + "Needs mentoring but eager to learn.")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     new JobPosition("Security Specialist"), new Team("Apple Store"),
-                    getTagSet("security", "senior")),
+                    getTagSet("security", "senior"),
+                    new Notes("Expert in iOS security protocols and penetration testing. "
+                            + "Previously led security at a major tech firm. "
+                            + "Identified critical vulnerabilities in App Store submission process. "
+                            + "Strong security mindset. "
+                            + "Published research on mobile app security. "
+                            + "Excellent communicator when explaining complex security concepts.")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Address("Blk 47 Tampines Street 20, #17-35"),
                     new JobPosition("Software Engineer"), new Team("macOS"),
-                    getTagSet("cpp", "junior")),
+                    getTagSet("cpp", "junior"),
+                    new Notes("Good foundation in C++. First interview showed promising problem-solving skills. "
+                            + "Could benefit from more exposure to large-scale systems.")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Address("Blk 45 Aljunied Street 85, #11-31"),
                     new JobPosition("Product Manager"), new Team("iOS Development"),
-                    getTagSet("agile", "experienced"))
+                    getTagSet("agile", "experienced"),
+                    new Notes("10 years of product management in mobile apps. Strong track record of launches. "
+                            + "Excellent stakeholder management skills. Deep understanding of the iOS ecosystem. "
+                            + "Advocates for user privacy and accessibility in product decisions."))
         };
     }
 
@@ -64,5 +87,4 @@ public class SampleDataUtil {
                 .map(Tag::new)
                 .collect(Collectors.toSet());
     }
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.JobPosition;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Team;
@@ -32,6 +33,7 @@ class JsonAdaptedPerson {
     private final String address;
     private final String jobPosition;
     private final String team;
+    private final String notes;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -41,6 +43,7 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                              @JsonProperty("email") String email, @JsonProperty("address") String address,
                              @JsonProperty("jobPosition") String jobPosition, @JsonProperty("team") String team,
+                             @JsonProperty("notes") String notes,
                              @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
@@ -48,6 +51,7 @@ class JsonAdaptedPerson {
         this.address = address;
         this.jobPosition = jobPosition;
         this.team = team;
+        this.notes = notes;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -63,13 +67,14 @@ class JsonAdaptedPerson {
         address = source.getAddress().value;
         jobPosition = source.getJobPosition().value;
         team = source.getTeam().value;
+        notes = source.getNotes().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
     }
 
     /**
-     * Converts this Jackson-friendly adapted person object into the model's {@code Candidate} object.
+     * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
@@ -129,8 +134,11 @@ class JsonAdaptedPerson {
         }
         final Team modelTeam = new Team(team);
 
+        final Notes modelNotes = new Notes(notes != null ? notes : "");
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelJobPosition, modelTeam, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelJobPosition,
+                modelTeam, modelTags, modelNotes);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -66,8 +66,7 @@ public class PersonCard extends UiPart<Region> {
                     Label tagLabel = new Label(tag.tagName);
                     tags.getChildren().add(tagLabel);
                 });
-
-        interviewerNotes.setText("");
+        interviewerNotes.setText(person.getNotes().value);
     }
 
     /**

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -382,35 +382,35 @@
 /* Notes section styling */
 .notes-section {
     -fx-background-color: #f5f5f7;
+    -fx-background-radius: 8px;
+    -fx-border-radius: 8px;
     -fx-border-color: #e6e6e6;
-    -fx-border-width: 1;
-    -fx-border-radius: 6px;
-    -fx-background-radius: 6px;
-    -fx-padding: 8 8 8 8;
+    -fx-border-width: 1px;
 }
 
 .notes-header {
     -fx-font-family: "SF Pro Text", "Helvetica Neue", Helvetica, sans-serif;
-    -fx-font-size: 11pt;
+    -fx-font-size: 13px;
     -fx-font-weight: bold;
     -fx-text-fill: #333333;
 }
 
-
 .notes-display-container {
-    -fx-background-color: white;
-    -fx-background-radius: 4px;
-    -fx-border-radius: 4px;
-    -fx-border-color: #e0e0e0;
+    -fx-background-color: #ffffff;
+    -fx-background-radius: 6px;
+    -fx-border-radius: 6px;
+    -fx-border-color: #e6e6e6;
     -fx-border-width: 1px;
-    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.05), 2, 0, 0, 1);
 }
 
 .notes-content {
     -fx-font-family: "SF Pro Text", "Helvetica Neue", Helvetica, sans-serif;
-    -fx-font-size: 11pt;
+    -fx-font-size: 13px;
     -fx-text-fill: #333333;
     -fx-wrap-text: true;
+    -fx-pref-width: 500px;
+    -fx-max-width: 500px;
+    -fx-line-spacing: 4px;
 }
 
 /* Apple-specific tag colors for different departments */

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -40,16 +40,16 @@
 
     <VBox alignment="TOP_LEFT" minHeight="140" GridPane.columnIndex="1" styleClass="notes-section">
       <padding>
-        <Insets top="8" right="10" bottom="8" left="5" />
+        <Insets top="8" right="10" bottom="8" left="10" />
       </padding>
       <Label text="Interviewer Notes:" styleClass="notes-header" />
       <Region minHeight="8" />
 
       <StackPane styleClass="notes-display-container" VBox.vgrow="ALWAYS">
         <padding>
-          <Insets top="5" right="5" bottom="5" left="5" />
+          <Insets top="8" right="8" bottom="8" left="8" />
         </padding>
-        <Label fx:id="interviewerNotes" text="" styleClass="notes-content" wrapText="true" />
+        <Label fx:id="interviewerNotes" text="" styleClass="notes-content" wrapText="true" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" />
       </StackPane>
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/logic/commands/NotesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NotesCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Notes;
+import seedu.address.model.person.Person;
+
+
+public class NotesCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_addNotes_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new Person(firstPerson.getName(), firstPerson.getPhone(), firstPerson.getEmail(),
+                firstPerson.getAddress(), firstPerson.getJobPosition(), firstPerson.getTeam(),
+                firstPerson.getTags(), new Notes("Test notes"));
+
+        NotesCommand notesCommand = new NotesCommand(INDEX_FIRST_PERSON, new Notes("Test notes"));
+
+        String expectedMessage = String.format(NotesCommand.MESSAGE_ADD_NOTES_SUCCESS,
+                INDEX_FIRST_PERSON.getOneBased(), "Test notes");
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(notesCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        NotesCommand notesCommand = new NotesCommand(outOfBoundIndex, new Notes("Test notes"));
+
+        assertCommandFailure(notesCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        NotesCommand notesCommand = new NotesCommand(outOfBoundIndex, new Notes("Test notes"));
+
+        assertCommandFailure(notesCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final Notes notes = new Notes("Test notes");
+        final NotesCommand standardCommand = new NotesCommand(INDEX_FIRST_PERSON, notes);
+
+        // same values -> returns true
+        NotesCommand commandWithSameValues = new NotesCommand(INDEX_FIRST_PERSON, notes);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new NotesCommand(INDEX_SECOND_PERSON, notes)));
+
+        // different notes -> returns false
+        Notes differentNotes = new Notes("Different notes");
+        assertFalse(standardCommand.equals(new NotesCommand(INDEX_FIRST_PERSON, differentNotes)));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/NotesCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NotesCommandParserTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.NotesCommand;
+import seedu.address.model.person.Notes;
+
+public class NotesCommandParserTest {
+
+    private NotesCommandParser parser = new NotesCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsNotesCommand() {
+        // with notes
+        assertParseSuccess(parser, "1 Test notes",
+                new NotesCommand(INDEX_FIRST_PERSON, new Notes("Test notes")));
+
+        // with notes containing multiple spaces
+        assertParseSuccess(parser, "1 Test   notes  with   spaces",
+                new NotesCommand(INDEX_FIRST_PERSON, new Notes("Test   notes  with   spaces")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // no index
+        assertParseFailure(parser, "Test notes",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+
+        // no notes
+        assertParseFailure(parser, "1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+
+        // negative index
+        assertParseFailure(parser, "-1 Test notes",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+
+        // zero index
+        assertParseFailure(parser, "0 Test notes",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+
+        // non-numeric index
+        assertParseFailure(parser, "abc Test notes",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NotesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_notesTooLong_throwsParseException() {
+        String longNotes = "a".repeat(Notes.MAX_LENGTH + 1);
+        assertParseFailure(parser, "1 " + longNotes,
+                String.format(MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED, longNotes.length()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/NotesTest.java
+++ b/src/test/java/seedu/address/model/person/NotesTest.java
@@ -1,0 +1,53 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NotesTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Notes(null));
+    }
+
+    @Test
+    public void isValidNotes() {
+        // null notes
+        assertThrows(NullPointerException.class, () -> Notes.isValidNotes(null));
+
+        // valid notes
+        assertTrue(Notes.isValidNotes("")); // empty string
+        assertTrue(Notes.isValidNotes(" ")); // spaces only
+        assertTrue(Notes.isValidNotes("Good candidate")); // normal notes
+        assertTrue(Notes.isValidNotes("Very detailed notes with multiple sentences. Shows promise in leadership."));
+        assertTrue(Notes.isValidNotes("a".repeat(Notes.MAX_LENGTH))); // exactly maximum characters
+
+        // invalid notes
+        assertFalse(Notes.isValidNotes("a".repeat(Notes.MAX_LENGTH + 1))); // exceeds maximum length
+    }
+
+    @Test
+    public void equals() {
+        Notes notes = new Notes("Test notes");
+
+        // same object -> returns true
+        assertTrue(notes.equals(notes));
+
+        // same value -> returns true
+        Notes sameNotes = new Notes("Test notes");
+        assertTrue(notes.equals(sameNotes));
+
+        // null -> returns false
+        assertFalse(notes.equals(null));
+
+        // different type -> returns false
+        assertFalse(notes.equals(5));
+
+        // different value -> returns false
+        Notes differentNotes = new Notes("Different notes");
+        assertFalse(notes.equals(differentNotes));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -103,7 +103,7 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
                 + ", jobPosition=" + ALICE.getJobPosition() + ", team=" + ALICE.getTeam()
-                + ", tags=" + ALICE.getTags() + "}";
+                + ", tags=" + ALICE.getTags() + ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -34,6 +34,7 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final String VALID_JOB_POSITION = BENSON.getJobPosition().toString();
     private static final String VALID_TEAM = BENSON.getTeam().toString();
+    private static final String VALID_NOTES = BENSON.getNotes().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -48,7 +49,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                        VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,7 +57,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,7 +66,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                        VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -73,7 +74,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +83,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                        VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -90,7 +91,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -99,7 +100,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                        VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -107,7 +108,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -116,7 +117,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidJobPosition_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        INVALID_JOB_POSITION, VALID_TEAM, VALID_TAGS);
+                        INVALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = JobPosition.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -124,7 +125,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullJobPosition_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_TEAM, VALID_TAGS);
+                null, VALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, JobPosition.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -133,7 +134,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTeam_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_JOB_POSITION, INVALID_TEAM, VALID_TAGS);
+                        VALID_JOB_POSITION, INVALID_TEAM, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Team.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -141,7 +142,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullTeam_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_JOB_POSITION, null, VALID_TAGS);
+                VALID_JOB_POSITION, null, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Team.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -152,7 +153,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_JOB_POSITION, VALID_TEAM, invalidTags);
+                        VALID_JOB_POSITION, VALID_TEAM, VALID_NOTES, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 }


### PR DESCRIPTION
This PR introduces the Interviewer Notes feature, allowing users to attach and view notes for each person in RecruitIntel. This enhances the application's usefulness for interview tracking and candidate evaluation.

Key Changes
- Added a Notes field to the Person class.

- Updated sample data to include interview notes.

- Modified relevant parsers and commands to support notes input/output.

- Updated UI to display notes in the person card view.

- Added test cases for notes-related functionality.

Rationale
This feature supports users (e.g., recruiters or hiring managers) in recording qualitative observations during candidate interviews, which can then be reviewed for decision-making