### PR TITLE
Undo command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
             "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_NOTES_CHARACTER_LIMIT_EXCEEDED =
             "Notes cannot exceed 450 characters. Current length: %1$d characters.";
+    public static final String MESSAGE_NO_COMMAND_TO_UNDO = "There is no command to undo.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEAM;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -58,14 +59,21 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-
         model.addPerson(toAdd);
+        lastCommand = this;
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+    }
+
+    @Override
+    public CommandResult undo(Model model) throws CommandException {
+        model.deletePerson(toAdd);
+        lastCommand = new DeleteCommand(toAdd);
+        return new CommandResult(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS
+                , Messages.format(toAdd)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEAM;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -72,8 +71,8 @@ public class AddCommand extends Command {
     public CommandResult undo(Model model) throws CommandException {
         model.deletePerson(toAdd);
         lastCommand = new DeleteCommand(toAdd);
-        return new CommandResult(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS
-                , Messages.format(toAdd)));
+        return new CommandResult(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(toAdd)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,40 +4,24 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Clears the RecruitIntel.
  */
 public class ClearCommand extends Command {
-    public static ReadOnlyAddressBook current;
-    public static ReadOnlyAddressBook previous;
-
-    public static ReadOnlyAddressBook empty = new AddressBook();
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "RecruitIntel has been cleared!";
 
-    public static final String MESSAGE_UNDO_CLEAR_SUCCESS = "RecruitIntel has been restored!";
-
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        previous = model.getAddressBook();
-        current = empty;
-        model.setAddressBook(current);
-        lastCommand = this;
+        model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override
     public CommandResult undo(Model model) {
-        model.setAddressBook(previous);
-        ReadOnlyAddressBook temp = previous;
-        previous = current;
-        current = temp;
-        lastCommand = this;
-        return new CommandResult(MESSAGE_UNDO_CLEAR_SUCCESS);
+        return new CommandResult("Undo not available for clear command");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Clears the RecruitIntel.
@@ -12,16 +13,27 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "RecruitIntel has been cleared!";
+    public static final String MESSAGE_UNDO_SUCCESS = "RecruitIntel has been restored!";
+    private ReadOnlyAddressBook currentAddressBook;
+    private ReadOnlyAddressBook previousAddressBook;
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        currentAddressBook = new AddressBook(model.getAddressBook());
+        previousAddressBook = new AddressBook();
+        model.setAddressBook(previousAddressBook);
+        lastCommand = this;
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override
     public CommandResult undo(Model model) {
-        return new CommandResult("Undo not available for clear command");
+        model.setAddressBook(currentAddressBook);
+        ReadOnlyAddressBook tempt = currentAddressBook;
+        currentAddressBook = previousAddressBook;
+        previousAddressBook = tempt;
+        lastCommand = this;
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -4,20 +4,40 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Clears the RecruitIntel.
  */
 public class ClearCommand extends Command {
+    public static ReadOnlyAddressBook current;
+    public static ReadOnlyAddressBook previous;
+
+    public static ReadOnlyAddressBook empty = new AddressBook();
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "RecruitIntel has been cleared!";
+
+    public static final String MESSAGE_UNDO_CLEAR_SUCCESS = "RecruitIntel has been restored!";
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        previous = model.getAddressBook();
+        current = empty;
+        model.setAddressBook(current);
+        lastCommand = this;
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public CommandResult undo(Model model) {
+        model.setAddressBook(previous);
+        ReadOnlyAddressBook temp = previous;
+        previous = current;
+        current = temp;
+        lastCommand = this;
+        return new CommandResult(MESSAGE_UNDO_CLEAR_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
  */
 public abstract class Command {
 
-    public static Command lastCommand = null;
+    protected static Command lastCommand = null;
 
     /**
      * Executes the command and returns the result message.

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -8,6 +8,8 @@ import seedu.address.model.Model;
  */
 public abstract class Command {
 
+    public static Command lastCommand = null;
+
     /**
      * Executes the command and returns the result message.
      *
@@ -16,5 +18,7 @@ public abstract class Command {
      * @throws CommandException If an error occurs during command execution.
      */
     public abstract CommandResult execute(Model model) throws CommandException;
+
+    public abstract CommandResult undo(Model model) throws CommandException;
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,8 +27,15 @@ public class DeleteCommand extends Command {
 
     private final Index targetIndex;
 
+    private Person deletedPerson = null;
+
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
+    }
+
+    public DeleteCommand(Person person) {
+        this.targetIndex = Index.fromZeroBased(0);
+        this.deletedPerson = person;
     }
 
     @Override
@@ -42,7 +49,17 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        deletedPerson = personToDelete;
+        lastCommand = this;
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+    }
+
+    @Override
+    public CommandResult undo(Model model) throws CommandException {
+        requireNonNull(model);
+        model.addPerson(deletedPerson);
+        lastCommand = new AddCommand(deletedPerson);
+        return new CommandResult(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(deletedPerson)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -33,6 +33,9 @@ public class DeleteCommand extends Command {
         this.targetIndex = targetIndex;
     }
 
+    /**
+     * Creates a DeleteCommand with a person.
+     */
     public DeleteCommand(Person person) {
         this.targetIndex = Index.fromZeroBased(0);
         this.deletedPerson = person;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -27,6 +27,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.JobPosition;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Team;
@@ -112,16 +113,17 @@ public class EditCommand extends Command {
         JobPosition updatedJobPosition = editPersonDescriptor.getJobPosition().orElse(personToEdit.getJobPosition());
         Team updatedTeam = editPersonDescriptor.getTeam().orElse(personToEdit.getTeam());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Notes notes = personToEdit.getNotes();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedJobPosition,
-                updatedTeam, updatedTags);
+                updatedTeam, updatedTags, notes);
     }
 
     @Override
     public CommandResult undo(Model model) throws CommandException {
         requireNonNull(model);
 
-        model.setPerson(personToEdit, editedPerson);
+        model.setPerson(editedPerson, personToEdit);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         Person temp = personToEdit;
@@ -168,6 +170,7 @@ public class EditCommand extends Command {
         private JobPosition jobPosition;
         private Team team;
         private Set<Tag> tags;
+        private Notes notes;
 
         public EditPersonDescriptor() {}
 
@@ -183,6 +186,11 @@ public class EditCommand extends Command {
             setJobPosition(toCopy.jobPosition);
             setTeam(toCopy.team);
             setTags(toCopy.tags);
+            setNotes(toCopy.notes);
+        }
+
+        private void setNotes(Notes notes) {
+            this.notes = notes;
         }
 
         /**
@@ -288,6 +296,7 @@ public class EditCommand extends Command {
                     .add("jobPosition", jobPosition)
                     .add("team", team)
                     .add("tags", tags)
+                    .add("notes", notes)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -11,9 +11,15 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting RecruitIntel as requested ...";
 
+    public static final String MESSAGE_UNDO_NOT_AVAILABLE = "Cannot undo exit command!";
+
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 
+    @Override
+    public CommandResult undo(Model model) {
+        return new CommandResult(MESSAGE_UNDO_NOT_AVAILABLE);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -35,6 +35,11 @@ public class FindCommand extends Command {
     }
 
     @Override
+    public CommandResult undo(Model model) {
+        return new CommandResult("FindCommand should not appear in the undo stack");
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -18,4 +18,9 @@ public class HelpCommand extends Command {
     public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
+
+    @Override
+    public CommandResult undo(Model model) {
+        return new CommandResult("HelpCommand should not appear in the undo stack");
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -21,4 +21,9 @@ public class ListCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    @Override
+    public CommandResult undo(Model model) {
+        return new CommandResult("ListCommand should not appear in undo stack.");
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/NotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NotesCommand.java
@@ -68,6 +68,7 @@ public class NotesCommand extends Command {
         );
 
         model.setPerson(personToAddNotesTo, updatedPerson);
+        targetPerson = updatedPerson;
         lastCommand = this;
         return new CommandResult(String.format(MESSAGE_ADD_NOTES_SUCCESS, targetIndex.getOneBased(), notes.value));
     }
@@ -91,6 +92,7 @@ public class NotesCommand extends Command {
         notes = temptNotes;
 
         model.setPerson(personToRemoveNotesFrom, updatedPerson);
+        targetPerson = updatedPerson;
         lastCommand = this;
         return new CommandResult(String.format(MESSAGE_ADD_NOTES_SUCCESS, targetIndex.getOneBased(), notes.value));
     }

--- a/src/main/java/seedu/address/logic/commands/NotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NotesCommand.java
@@ -27,7 +27,9 @@ public class NotesCommand extends Command {
     public static final String MESSAGE_ADD_NOTES_SUCCESS = "Note added to candidate #%1$d: \"%2$s\"";
 
     private final Index targetIndex;
-    private final Notes notes;
+    private Notes notes;
+    private Person targetPerson;
+    private Notes lastNotes;
 
     /**
      * @param targetIndex of the candidate in the filtered candidate list to add notes to
@@ -51,6 +53,9 @@ public class NotesCommand extends Command {
         }
 
         Person personToAddNotesTo = lastShownList.get(targetIndex.getZeroBased());
+        targetPerson = personToAddNotesTo;
+        lastNotes = personToAddNotesTo.getNotes();
+
         Person updatedPerson = new Person(
                 personToAddNotesTo.getName(),
                 personToAddNotesTo.getPhone(),
@@ -63,7 +68,30 @@ public class NotesCommand extends Command {
         );
 
         model.setPerson(personToAddNotesTo, updatedPerson);
+        lastCommand = this;
+        return new CommandResult(String.format(MESSAGE_ADD_NOTES_SUCCESS, targetIndex.getOneBased(), notes.value));
+    }
 
+    @Override
+    public CommandResult undo(Model model) throws CommandException {
+        requireNonNull(model);
+        Person personToRemoveNotesFrom = targetPerson;
+        Person updatedPerson = new Person(
+                personToRemoveNotesFrom.getName(),
+                personToRemoveNotesFrom.getPhone(),
+                personToRemoveNotesFrom.getEmail(),
+                personToRemoveNotesFrom.getAddress(),
+                personToRemoveNotesFrom.getJobPosition(),
+                personToRemoveNotesFrom.getTeam(),
+                personToRemoveNotesFrom.getTags(),
+                lastNotes
+        );
+        Notes temptNotes = lastNotes;
+        lastNotes = notes;
+        notes = temptNotes;
+
+        model.setPerson(personToRemoveNotesFrom, updatedPerson);
+        lastCommand = this;
         return new CommandResult(String.format(MESSAGE_ADD_NOTES_SUCCESS, targetIndex.getOneBased(), notes.value));
     }
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -36,6 +36,12 @@ public class UndoCommand extends Command {
     }
 
     @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || other instanceof UndoCommand; // instanceof handles nulls
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .toString();

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Notes;
+import seedu.address.model.person.Person;
+
+/**
+ * Undo the most recent command that modifies the data.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undo the most recent command that modifies the data.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Undo successful!";
+
+    public static final String MESSAGE_UNDO_NOT_AVAILABLE = "No command to undo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (lastCommand == null) {
+            throw new CommandException(Messages.MESSAGE_NO_COMMAND_TO_UNDO);
+        }
+        return lastCommand.undo(model);
+    }
+
+    @Override
+    public CommandResult undo(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_UNDO_NOT_AVAILABLE);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -2,15 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Notes;
-import seedu.address.model.person.Person;
 
 /**
  * Undo the most recent command that modifies the data.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NotesCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case NotesCommand.COMMAND_WORD:
             return new NotesCommandParser().parse(arguments);
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -3,14 +3,13 @@ package seedu.address.logic.parser;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new UndoCommand object
  */
-public class UndoCommandParser implements Parser<UndoCommand>{
+public class UndoCommandParser implements Parser<UndoCommand> {
     private static final Logger logger = LogsCenter.getLogger(UndoCommandParser.class);
 
     /**

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -23,7 +24,7 @@ public class UndoCommandParser implements Parser<UndoCommand> {
         if (!trimmedArgs.isEmpty()) {
             logger.info("Invalid arguments provided for undo command");
             throw new ParseException(
-                    String.format(UndoCommand.MESSAGE_USAGE));
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
         }
         return new UndoCommand();
     }

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UndoCommand object
+ */
+public class UndoCommandParser implements Parser<UndoCommand>{
+    private static final Logger logger = LogsCenter.getLogger(UndoCommandParser.class);
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UndoCommand
+     * and returns an UndoCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UndoCommand parse(String args) throws ParseException {
+        logger.info("Parsing undo command");
+        String trimmedArgs = args.trim();
+        if (!trimmedArgs.isEmpty()) {
+            logger.info("Invalid arguments provided for undo command");
+            throw new ParseException(
+                    String.format(UndoCommand.MESSAGE_USAGE));
+        }
+        return new UndoCommand();
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -41,7 +41,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// list overwrite operations
 
     /**
-     * Replaces the contents of the person list with {@code candidates}.
+     * Replaces the contents of the candidates list with {@code candidates}.
      * {@code candidates} must not contain duplicate persons.
      */
     public void setPersons(List<Person> persons) {

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -61,7 +61,8 @@ public class EditPersonDescriptorTest {
     public void toStringMethod() {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String expected = EditPersonDescriptor.class.getCanonicalName()
-                + "{name=null, phone=null, email=null, address=null, jobPosition=null, team=null, tags=null}";
+                + "{name=null, phone=null, email=null, address=null, "
+                + "jobPosition=null, team=null, tags=null, notes=null}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for UndoCommand.
+ */
+public class UndoCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_undoDeleteCommand_success() {
+        Person firstPerson = model.getFilteredPersonList().get(6);
+
+        DeleteCommand deleteCommand = new DeleteCommand(firstPerson);
+        try {
+            deleteCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        UndoCommand undoCommand = new UndoCommand();
+
+        try {
+            undoCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(model.getFilteredPersonList().size(), 7);
+    }
+
+    @Test
+    public void execute_doubleUndoDeleteCommand_success() {
+        Person firstPerson = model.getFilteredPersonList().get(6);
+
+        DeleteCommand deleteCommand = new DeleteCommand(firstPerson);
+        try {
+            deleteCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        UndoCommand undoCommand = new UndoCommand();
+
+        try {
+            undoCommand.execute(model);
+            undoCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(model.getFilteredPersonList().size(), 6);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UndoCommand;
+
+
+
+public class UndoCommandParserTest {
+
+    private UndoCommandParser parser = new UndoCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUndoCommand() {
+        assertParseSuccess(parser, "", new UndoCommand());
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // no index
+        assertParseFailure(parser, "what ever user input",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+
+        // non-numeric index
+        assertParseFailure(parser, "abc", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+
+        // negative index
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+
+        // zero index
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Implement the undo command which will undo all data modification.
To be specific, only the following command can be undo:
- add
- delete
- clear
- edit
- note

Execute undo command several times in a row will flip only in the past 2 states. For example, undo a add command will delete the latest added candidate, undo again will add back that candidate.

Undo command will find the last undoable command. For example after execute the clear command, perform any other command that will not modify data for any times will not affect undo the clear command.